### PR TITLE
docs: fix 404 link to TradingView MCP repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,6 @@ Additional guardrails that apply regardless of strategy:
 ## Resources
 
 - [First video — Connect Claude to TradingView](https://youtu.be/vIX6ztULs4U)
-- [TradingView MCP repo (first video)](https://github.com/jackson-video-resources/tradingview-mcp-jackson)
+- [TradingView MCP repo (first video)](https://github.com/LewisWJackson/tradingview-mcp-jackson)
 - [Apify](https://apify.com?fpr=3ly3yd) — search actor store for "YouTube Transcript Scraper"
 - [BitGet — $1,000 bonus on first deposit]([https://partner.bitget.com/bg/LewisJackson](https://bonus.bitget.com/LewisJackson))


### PR DESCRIPTION
## What

One-line link fix in the Resources section of README.md.

## Why

The Resources section linked to:

```
https://github.com/jackson-video-resources/tradingview-mcp-jackson
```

…which returns **404** (no such repo in this org). The actual MCP repo — the one this README references throughout as a prerequisite ("Watch the previous video first — it sets up the TradingView MCP connection this builds on") — lives at:

```
https://github.com/LewisWJackson/tradingview-mcp-jackson
```

Verified via `gh repo view` on both URLs and against the YouTube video's own description.

I hit this following the README — followed the resource link, got 404, had to search for the real repo. Quick fix.